### PR TITLE
Detect if one quarter is symetric and allow player to skip the rotati…

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 import numpy as np
 
-from constant.board import BOARD_SIZE, WIN_CONDITION, WIN_AREA_CHECK
+from constant.board import BOARD_SIZE, WIN_CONDITION, WIN_AREA_CHECK, QUARTER_BOUNDARIES
 
 def construct_board():
     return np.array([[0] * BOARD_SIZE for _ in range(BOARD_SIZE)], int)
@@ -98,15 +98,8 @@ Warning: in slice(X, Y), X is included but Y is excluded.
 
 """
 
-
 def get_quarter_boundaries_from_rotation_key(rotation_key):
-    return {
-        0: (slice(0, 3), slice(0, 3)),
-        1: (slice(0, 3), slice(3, 6)),
-        2: (slice(3, 6), slice(3, 6)),
-        3: (slice(3, 6), slice(0, 3))
-    }[rotation_key // 2]
-
+    return QUARTER_BOUNDARIES[rotation_key // 2]
 
 def rotate_quarter_of_board(board, player_input_value):
     try:
@@ -181,3 +174,35 @@ def rotate_quarter_of_board(board, player_input_value):
     board[slices] = rotated_quarter
 
     return board
+
+
+def is_quarter_symetric(quarter):
+    """  
+        A quarter have a rotational symetry if "A" cells "A" and "B" cells have the same values.
+        B and A can equal 0, 1 or 2.
+        ┌─────────+
+        | A  B  A |
+        | B  x  B |
+        | A  B  A |
+        |─────────+
+
+        To check this, we need to compare the quarter with himself 180deg rotated.
+    """
+
+    # 2 apply rot90 twice to got 180deg rotation.
+    rotated_quarter = np.rot90(quarter, 2)
+
+    # NumPy array comparaison to deeply compare sizes and values.
+    return np.array_equal(quarter, rotated_quarter)
+
+def is_at_least_one_quarter_symetric(board):
+    # Get all quarter slices 
+    for slices in QUARTER_BOUNDARIES.values():
+        # Extract this quarter
+        quarter = board[slices]
+        # If symetric, return True
+        is_symetric = is_quarter_symetric(quarter)
+
+        if is_symetric:
+            return True
+    return False

--- a/src/board.py
+++ b/src/board.py
@@ -101,7 +101,11 @@ Warning: in slice(X, Y), X is included but Y is excluded.
 def get_quarter_boundaries_from_rotation_key(rotation_key):
     return QUARTER_BOUNDARIES[rotation_key // 2]
 
-def rotate_quarter_of_board(board, player_input_value):
+def rotate_quarter_of_board(board, player_input_value, one_quarter_is_symetric):
+    # If one quarter is symetric, we allow player to skip this step.
+    if one_quarter_is_symetric == True and len(player_input_value) == 0:
+        return board
+
     try:
         # Trying to convert the given string to an integer.
         rotation_key = int(player_input_value)

--- a/src/constant/board.py
+++ b/src/constant/board.py
@@ -4,3 +4,10 @@ HALF_BOARD_SIZE = (BOARD_SIZE / 2)
 
 WIN_CONDITION = 5
 WIN_AREA_CHECK = BOARD_SIZE - WIN_CONDITION + 1
+
+QUARTER_BOUNDARIES = {
+    0: (slice(0, 3), slice(0, 3)),
+    1: (slice(0, 3), slice(3, 6)),
+    2: (slice(3, 6), slice(3, 6)),
+    3: (slice(3, 6), slice(0, 3))
+}

--- a/src/game.py
+++ b/src/game.py
@@ -7,6 +7,7 @@ class Game:
         self.board = construct_board()
         self.players = construct_players(name1, name2)
         self.current_player_id = current_player_id
+        self.one_quarter_is_symetric = True
 
 def construct_players(name1, name2):
     return (

--- a/src/pentago.py
+++ b/src/pentago.py
@@ -3,7 +3,7 @@ from random import randint
 from constant.ui import PRINT_BOARD_PLACE_MARBLE, PRINT_BOARD_ROTATE, PRINT_BOARD_FINISHED
 from game import Game, player_finished_his_turn
 
-from board import add_marble_to_board, is_board_full, get_position_if_valid, rotate_quarter_of_board
+from board import add_marble_to_board, is_board_full, get_position_if_valid, rotate_quarter_of_board, is_at_least_one_quarter_symetric
 
 from render import print_game
 
@@ -24,8 +24,11 @@ def init_game():
             game.board = ask_player_to_place_marble(
                 game.board, game.current_player_id
             )
+
+            game.one_quarter_is_symetric = is_at_least_one_quarter_symetric(game.board)
+    
             print_game(game, PRINT_BOARD_ROTATE)
-            game.board = ask_player_to_rotate_quarter(game.board)
+            game.board = ask_player_to_rotate_quarter(game.board, game.one_quarter_is_symetric)
 
             game.current_player_id = player_finished_his_turn(
                 game.current_player_id
@@ -63,12 +66,19 @@ def ask_player_to_place_marble(board, current_player_id):
 
     return board
 
-def ask_player_to_rotate_quarter(board):
+def ask_player_to_rotate_quarter(board, one_quarter_is_symetric):
     player_input_value_is_wrong = True;
     
     while player_input_value_is_wrong:
-        player_input_value = input(" Now rotate one quarter: ")
+        string = " Now rotate one quarter: "
+        if one_quarter_is_symetric == True:
+            string += "(enter to skip) "
 
+        player_input_value = input(string)
+
+        if one_quarter_is_symetric == True and len(player_input_value) == 0:
+            return board
+        
         try:
             board = rotate_quarter_of_board(board, player_input_value)
             player_input_value_is_wrong = False

--- a/src/pentago.py
+++ b/src/pentago.py
@@ -75,12 +75,9 @@ def ask_player_to_rotate_quarter(board, one_quarter_is_symetric):
             string += "(enter to skip) "
 
         player_input_value = input(string)
-
-        if one_quarter_is_symetric == True and len(player_input_value) == 0:
-            return board
         
         try:
-            board = rotate_quarter_of_board(board, player_input_value)
+            board = rotate_quarter_of_board(board, player_input_value, one_quarter_is_symetric)
             player_input_value_is_wrong = False
         except ValueError:
             print("Please enter a valid rotation (1..8): ")

--- a/src/test_board.py
+++ b/src/test_board.py
@@ -3,9 +3,9 @@ from unittest_data_provider import data_provider
 import sys
 import numpy as np
 
-from board import construct_board, is_board_full, get_position_if_valid, add_marble_to_board, get_quarter_boundaries_from_rotation_key, rotate_quarter_of_board
+from board import *
 
-from test_utils.generate_board import generate_board_and_add_position, generate_empty_board, generate_full_board
+from test_utils.generate_board import generate_board_and_add_position, generate_empty_board, generate_full_board, generate_board_and_add_positions
 from test_utils.print_board import print_board_if_verbosity_is_set
 
 class BoardTest (unittest.TestCase):
@@ -156,3 +156,30 @@ class BoardTest (unittest.TestCase):
 
 
         self.assertEqual("Rotation given is not correct", str(context.exception))
+
+    is_quarter_symetric_values = lambda: (
+        ([[0, 0, 0], [0, 0, 0], [0, 0, 0]], True),
+        ([[0, 1, 0], [0, 0, 0], [0, 0, 0]], False),
+        ([[1, 0, 1], [0, 0, 0], [1, 0, 1]], True),
+        ([[1, 0, 1], [0, 0, 0], [1, 0, 1]], True),
+        ([[1, 2, 1], [2, 0, 2], [1, 2, 1]], True),
+    )
+    @data_provider(is_quarter_symetric_values)
+    def test_is_quarter_symetric(self, quarter, expected_result):
+        print_board_if_verbosity_is_set(quarter)
+
+        result = is_quarter_symetric(quarter)
+
+        self.assertEqual(result, expected_result)
+
+    is_at_least_one_quarter_symetric_values = lambda: (
+        (generate_board_and_add_positions(((0, 0), (3, 0), (3, 3), (0, 3))), False),
+        (generate_empty_board(), True),
+    )
+    @data_provider(is_at_least_one_quarter_symetric_values)
+    def test_is_at_least_one_quarter_symetric(self, board, expected_result):
+        print_board_if_verbosity_is_set(board)
+
+        result = is_at_least_one_quarter_symetric(board)
+
+        self.assertEqual(result, expected_result)

--- a/src/test_board.py
+++ b/src/test_board.py
@@ -121,21 +121,23 @@ class BoardTest (unittest.TestCase):
 
     
     good_rotation_values = lambda: (
-        ( "1", generate_board_and_add_position((0, 0)), generate_board_and_add_position((2, 0)) ),
-        ( "2", generate_board_and_add_position((0, 0)), generate_board_and_add_position((0, 2)) ),
-        ( "3", generate_board_and_add_position((0, 3)), generate_board_and_add_position((2, 3)) ),
-        ( "4", generate_board_and_add_position((0, 3)), generate_board_and_add_position((0, 5)) ),
-        ( "5", generate_board_and_add_position((3, 3)), generate_board_and_add_position((5, 3)) ),
-        ( "6", generate_board_and_add_position((3, 3)), generate_board_and_add_position((3, 5)) ),
-        ( "7", generate_board_and_add_position((3, 0)), generate_board_and_add_position((5, 0)) ),
-        ( "8", generate_board_and_add_position((3, 0)), generate_board_and_add_position((3, 2)) ),
+        ( "", generate_board_and_add_position((0, 0)), True, generate_board_and_add_position((0, 0)) ),
+        ( "1", generate_board_and_add_position((0, 0)), False, generate_board_and_add_position((2, 0)) ),
+        ( "1", generate_board_and_add_position((0, 0)), True, generate_board_and_add_position((2, 0)) ),
+        ( "2", generate_board_and_add_position((0, 0)), False, generate_board_and_add_position((0, 2)) ),
+        ( "3", generate_board_and_add_position((0, 3)), False, generate_board_and_add_position((2, 3)) ),
+        ( "4", generate_board_and_add_position((0, 3)), False, generate_board_and_add_position((0, 5)) ),
+        ( "5", generate_board_and_add_position((3, 3)), False, generate_board_and_add_position((5, 3)) ),
+        ( "6", generate_board_and_add_position((3, 3)), False, generate_board_and_add_position((3, 5)) ),
+        ( "7", generate_board_and_add_position((3, 0)), False, generate_board_and_add_position((5, 0)) ),
+        ( "8", generate_board_and_add_position((3, 0)), False, generate_board_and_add_position((3, 2)) ),
     )
 
     @data_provider(good_rotation_values)
-    def test_rotate_quarter_of_board_should_return_board(self, player_input_value, board, expected_board):
+    def test_rotate_quarter_of_board_should_return_board(self, player_input_value, board, one_quarter_is_symetric, expected_board):
         print_board_if_verbosity_is_set(board)
         print_board_if_verbosity_is_set(expected_board)
-        result = rotate_quarter_of_board(board, player_input_value)
+        result = rotate_quarter_of_board(board, player_input_value, one_quarter_is_symetric)
 
         np.testing.assert_array_equal(result, expected_board)
 
@@ -152,7 +154,7 @@ class BoardTest (unittest.TestCase):
         print_board_if_verbosity_is_set(board)
         
         with self.assertRaises(ValueError) as context:
-            board = rotate_quarter_of_board(board, player_input_value)
+            board = rotate_quarter_of_board(board, player_input_value, False)
 
 
         self.assertEqual("Rotation given is not correct", str(context.exception))

--- a/src/test_game.py
+++ b/src/test_game.py
@@ -17,6 +17,7 @@ class GameTest (unittest.TestCase):
         self.assertIsInstance(game.players[0], Player)
         self.assertIsInstance(game.players[1], Player)
         self.assertEqual(game.current_player_id, expected_current_player_id)
+        self.assertEqual(game.one_quarter_is_symetric, True)
 
 
     turn_values = lambda: (


### PR DESCRIPTION
# (1) As Brice, Given that one of the quadrants has rotational symmetry, I want to be able to skip rotating anything

- [x] Game class have now a boolean to tell that one quarter is symetric
- [x] After placing a marble, check 4 quarters if one is symetric and populate this bool
- [x] If (at least) one is symetric, allow user to skip the rotation step.

![symetric](https://user-images.githubusercontent.com/12797391/106176078-2a25ac00-6197-11eb-92a3-d510d199f0c8.gif)
